### PR TITLE
Reduce output volume

### DIFF
--- a/src/kle_colouriser.py
+++ b/src/kle_colouriser.py
@@ -76,10 +76,26 @@ def remove_private_data(data:Union[dict, list]) -> Union[dict,list]:
 def serialise_kle_data(data:[[dict]]) -> [[Union[dict, str]]]:
     serialised_output:[[Union[dict, str]]] = []
 
+    colour_state:dict = { 'c': None, 't': None }
+
     for row in data:
         for key in row:
-            serialised_output.append(key)
+            # Determine which colour-fields to output
+            colfields_to_output:[str] = []
+            for colfield in colour_state.keys():
+                if key[colfield] != colour_state[colfield]:
+                    colfields_to_output.append(colfield)
+
+            # Filter, format and append to output
+            fields_to_output:[str] = key['~original-keys'] + colfields_to_output
+            key_inf:dict = dict(filter(lambda p: p[0] in fields_to_output, key.items()))
+            if key_inf != {}:
+                serialised_output.append(key_inf)
             serialised_output.append(key['~raw-key'])
+
+            # Update colour state
+            for colfield in colour_state.keys():
+                colour_state[colfield] = key[colfield]
 
     # Sanitise before output
     remove_private_data(serialised_output)

--- a/src/kle_colouriser/parse_kle.py
+++ b/src/kle_colouriser/parse_kle.py
@@ -21,10 +21,11 @@ parser_initial_state:dict = {
     'pos': Vector((0.0, 0.0)),
     'origin': Vector((0.0, 0.0)),
     'offset': Vector((0.0, 0.0)),
+    '~original-keys': [],
 }
 parser_state_keys:[dict] = parser_initial_state.keys()
-parser_state_reset_keys:[str] = ['d', 'w', 'h', 'w2', 'h2', 'l', 'n', 'x', 'y']
-parser_state_output_keys:[str] = ['p', 'w', 'h', 'w2', 'h2', 'l', 'n', 'r', 'x', 'y', 'r', 'rx', 'ry']
+parser_state_reset_keys:[str] = ['d', 'w', 'h', 'w2', 'h2', 'l', 'n', 'x', 'y', '~original-keys']
+parser_state_output_keys:[str] = ['p', 'w', 'h', 'w2', 'h2', 'l', 'n', 'r', 'x', 'y', 'r', 'rx', 'ry', '~original-keys']
 
 def parse_kle(fname:str) -> [dict]:
     return parse_kle_raw(read_yaml(fname))
@@ -44,6 +45,7 @@ def parse_kle_raw(layout:Union[Union[str,dict],str]) -> [dict]:
                     for cap_key in cap.keys():
                         if cap_key in parser_state_keys:
                             setattr(parser_state, cap_key, cap[cap_key])
+                    setattr(parser_state, '~original-keys', getattr(parser_state, '~original-keys') + list(cap.keys()))
 
                     # Update the positioning information
                     if 'rx' in cap:


### PR DESCRIPTION
Previously, all fields and values implied by the kle format were output resulting in quite large and somewhat unreadable files to be created.
Now, a field is output if and only if:

- It is explicitly present in the original input
- Or, it is a colour field which has changed from the previous key outputted
